### PR TITLE
toml 0.10.2 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,11 +13,11 @@ source:
 
 build:
   number: 0
-  noarch: python
+  noarch: {{ noarch_python }}
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
-  build:
+  host:
     - python
     - pip
 
@@ -27,9 +27,6 @@ requirements:
 test:
   imports:
     - toml
-  commands:
-    - conda inspect linkages -p $PREFIX toml  # [not win]
-    - conda inspect objects -p $PREFIX toml   # [osx]
 
 about:
   home: https://github.com/uiri/toml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "toml" %}
-{% set version = "0.10.0" %}
-{% set sha256 = "229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c" %}
+{% set version = "0.10.2" %}
+{% set sha256 = "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f" %}
 
 package:
   name: {{ name|lower }}
@@ -13,27 +13,30 @@ source:
 
 build:
   number: 0
-  noarch: {{ noarch_python }}
-  script: python -m pip install --no-deps --ignore-installed .
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
-  host:
-    - python
+  build:
+    - python >=2.7
     - pip
 
   run:
-    - python
+    - python >=2.7
 
 test:
   imports:
     - toml
+  commands:
+    - conda inspect linkages -p $PREFIX toml  # [not win]
+    - conda inspect objects -p $PREFIX toml   # [osx]
 
 about:
   home: https://github.com/uiri/toml
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'Python lib for TOML.'
+  summary: Python lib for TOML.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
toml 0.10.2

**Destination channel:** Defaults

### Links

- [PKG-15125]
- dev_url:        https://github.com/uiri/toml/tree/0.10.2
- conda_forge:    n/a
- pypi:           https://pypi.org/project/toml/0.10.2
- pypi inspector: https://inspector.pypi.io/project/toml/0.10.2

### Explanation of changes:

- new build number
- remove `conda inspect` test commands which fail when tested against the `anaconda` metapackage


[PKG-15125]: https://anaconda.atlassian.net/browse/PKG-15125